### PR TITLE
Gulp

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,28 @@
+var gulp = require('gulp');
+var browserSync = require('browser-sync');
+var nodemon = require('gulp-nodemon');
+
+
+gulp.task('default', ['browser-sync'], function() {});
+
+gulp.task('browser-sync', ['nodemon'], function() {
+  browserSync.init(null, {
+    proxy: "http://localhost:3000",
+    files: ["**/*.*"],
+    browser: "google chrome",
+    port: 7000,
+  });
+});
+gulp.task('nodemon', function(cb) {
+
+  var started = false;
+
+  return nodemon({
+    script: 'bin/www'
+  }).on('start', function() {
+    if (!started) {
+      cb();
+      started = true;
+    }
+  });
+});

--- a/package.json
+++ b/package.json
@@ -14,5 +14,10 @@
     "morgan": "~1.6.1",
     "pmx": "^0.4.6",
     "serve-favicon": "~2.3.0"
+  },
+  "devDependencies": {
+    "browser-sync": "^2.9.5",
+    "gulp": "^3.9.0",
+    "gulp-nodemon": "^2.0.4"
   }
 }


### PR DESCRIPTION
* `npm install` protoze sem pridal veci
* `gulp`:
 * spusti server
 * zapne browser sync na portu 7000, ktery slouzit jako proxy k portu 3000
 * kdyz se zmeni js soubor tak to server vypne a zapne (snad, pro app.js sem to zkousel a jelo to)
 * kdyz se zmeni jakykoliv soubor tak to posle serveru prikaz aby si refreshnul stranku

kdyztak si pak pridaj neco na sass, stylus nebo cokoliv budes pouzivat